### PR TITLE
feat: Add support for cardinality aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: "stable"
           components: rustfmt
@@ -92,7 +92,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: ${{ matrix.allow-prereleases }}
 
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: "stable"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v2.2.5
+        uses: github/codeql-action/init@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v2.2.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,7 +61,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v2.2.5
+        uses: github/codeql-action/autobuild@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v2.2.5
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -74,6 +74,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v2.2.5
+        uses: github/codeql-action/analyze@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v2.2.5
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@96f518a34f7a870018057716cc4d7a5c014bd61c # v2.2.5
+        uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v2.2.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,7 +61,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@96f518a34f7a870018057716cc4d7a5c014bd61c # v2.2.5
+        uses: github/codeql-action/autobuild@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v2.2.5
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -74,6 +74,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@96f518a34f7a870018057716cc4d7a5c014bd61c # v2.2.5
+        uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v2.2.5
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -159,7 +159,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: "stable"
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -64,6 +64,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+        uses: github/codeql-action/upload-sarif@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -64,6 +64,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
+        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         with:
           sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tantivy.egg-info/
 .venv
 .envrc
 site/
+
+/.claude

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bitpacking"
@@ -115,9 +115,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",
@@ -207,9 +207,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08440b3dd222c3d0433e63e097463969485f112baff337dfdaca043a0d760570"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25b7912bc28a04ab1b7715a68ea03aaa15662b43a1a4b2c480531fd19f8bf7e"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce154b9bea7fb0c8e8326e62d00354000c36e79770ff21b8c84e3aa267d9d531"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
@@ -509,9 +509,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -589,9 +589,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
 ]
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rust-stemmers"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,18 +731,17 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
- "cfg-if",
  "chrono",
  "indoc",
  "libc",
  "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -750,39 +749,28 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
-dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -792,22 +780,22 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5bcac0d0b71821f0d69e42654f1e15e5c94b85196446c4de9588951a2117e7b"
+checksum = "11e06e4cff9be2bbf2bddf28a486ae619172ea57e79787f856572878c62dcfe2"
 dependencies = [
  "pyo3",
  "serde",
@@ -1065,7 +1053,7 @@ dependencies = [
  "futures",
  "itertools",
  "pyo3",
- "pyo3-build-config 0.25.1",
+ "pyo3-build-config",
  "pythonize",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,19 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -46,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -63,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -75,9 +63,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "bitpacking"
@@ -90,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baa8e2f74b721b16b14e6b8e0516c8df35708273d5e89ca7be391cb9a419ff9"
+checksum = "537c317ddf588aab15c695bf92cf55dec159b93221c074180ca3e0e5a94da415"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -100,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff68fc8bb0a7a05683bc799f9c50ec05379c4a6104446eb1fed7b07341eebc5"
+checksum = "ca5abbf2d4a4c6896197c9de13d6d7cb7eff438c63dacde1dde980569cb00248"
 dependencies = [
  "darling",
  "ident_case",
@@ -115,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -127,12 +115,13 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -143,9 +132,9 @@ checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
@@ -163,73 +152,64 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "08440b3dd222c3d0433e63e097463969485f112baff337dfdaca043a0d760570"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -237,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "d25b7912bc28a04ab1b7715a68ea03aaa15662b43a1a4b2c480531fd19f8bf7e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -251,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ce154b9bea7fb0c8e8326e62d00354000c36e79770ff21b8c84e3aa267d9d531"
 dependencies = [
  "darling_core",
  "quote",
@@ -262,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -278,25 +258,31 @@ checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "fastdivide"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -311,13 +297,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fs4"
-version = "0.8.2"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dabded2e32cd57ded879041205c60a4a4c4bab47bd0fd2fa8b01f30849f02b"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix 0.38.21",
- "windows-sys 0.52.0",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -411,20 +403,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -434,12 +426,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
  "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -465,14 +458,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -494,9 +488,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "itertools"
@@ -509,25 +503,27 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -539,21 +535,15 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -563,24 +553,24 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.1"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
 name = "measure_time"
@@ -593,24 +583,24 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -623,9 +613,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "murmurhash32"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9380db4c04d219ac5c51d14996bbf2c2e9a15229771b53f8671eb6c83cf44df"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nom"
@@ -645,9 +635,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -676,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -688,15 +678,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "powerfmt"
@@ -706,15 +696,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -722,40 +715,29 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
- "cfg-if",
  "chrono",
  "indoc",
  "libc",
  "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
-dependencies = [
- "once_cell",
- "target-lexicon",
 ]
 
 [[package]]
@@ -770,19 +752,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -792,22 +774,22 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5bcac0d0b71821f0d69e42654f1e15e5c94b85196446c4de9588951a2117e7b"
+checksum = "597907139a488b22573158793aa7539df36ae863eba300c75f3a0d65fc475e27"
 dependencies = [
  "pyo3",
  "serde",
@@ -815,18 +797,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -855,7 +837,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -870,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -880,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -890,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -902,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -913,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rust-stemmers"
@@ -935,47 +917,28 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.21"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.10",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
@@ -999,15 +962,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -1020,18 +989,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1047,9 +1013,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1065,18 +1031,18 @@ dependencies = [
  "futures",
  "itertools",
  "pyo3",
- "pyo3-build-config 0.25.1",
+ "pyo3-build-config",
  "pythonize",
  "serde",
  "serde_json",
- "tantivy 0.24.2",
+ "tantivy 0.25.0",
 ]
 
 [[package]]
 name = "tantivy"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
+checksum = "502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -1126,18 +1092,18 @@ dependencies = [
 
 [[package]]
 name = "tantivy-bitpacker"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc286a39e089ae9938935cd488d7d34f14502544a36607effd2239ff0e2494"
+checksum = "c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6"
 dependencies = [
  "bitpacking",
 ]
 
 [[package]]
 name = "tantivy-columnar"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
+checksum = "8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -1151,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-common"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b6ea6090ce03dc72c27d0619e77185d26cc3b20775966c346c6d4f7e99d7f"
+checksum = "f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1175,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e810cdeeebca57fc3f7bfec5f85fdbea9031b2ac9b990eb5ff49b371d52bbe6a"
+checksum = "768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b"
 dependencies = [
  "nom",
  "serde",
@@ -1186,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-sstable"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f22c08a4c90e1b36711c1c6cad5ae21b20b093e535b69b18783dd2cb99416"
+checksum = "f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5"
 dependencies = [
  "futures-util",
  "itertools",
@@ -1200,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-stacker"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcdebb267671311d1e8891fd9d1301803fdb8ad21ba22e0a30d0cab49ba59c1"
+checksum = "23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -1211,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-tokenizer-api"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa942fcee81e213e09715bbce8734ae2180070b97b33839a795ba1de201547d"
+checksum = "23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038"
 dependencies = [
  "serde",
 ]
@@ -1226,31 +1192,31 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1259,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -1274,15 +1240,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1290,15 +1256,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unindent"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8-ranges"
@@ -1308,25 +1274,21 @@ checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.3.3",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1339,23 +1301,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1364,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1374,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1387,9 +1350,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -1415,157 +1381,209 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-result"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -1578,18 +1596,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1598,27 +1616,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.14.0"
 futures = "0.3.31"
 pythonize = "0.24.0"
 serde = "1.0"
-serde_json = "1.0.142"
+serde_json = "1.0.143"
 
 [dependencies.pyo3]
 version = "0.24.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ pyo3-build-config = "0.25.1"
 [dependencies]
 base64 = "0.22"
 chrono = "0.4.41"
-tantivy = "0.24.2"
+tantivy = "0.25.0"
 itertools = "0.14.0"
 futures = "0.3.31"
-pythonize = "0.24.0"
+pythonize = "0.25.0"
 serde = "1.0"
 serde_json = "1.0.142"
 
 [dependencies.pyo3]
-version = "0.24.2"
+version = "0.25.0"
 features = ["chrono", "extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "tantivy"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-pyo3-build-config = "0.25.1"
+pyo3-build-config = "0.26.0"
 
 [dependencies]
 base64 = "0.22"
@@ -19,10 +19,10 @@ chrono = "0.4.41"
 tantivy = "0.24.2"
 itertools = "0.14.0"
 futures = "0.3.31"
-pythonize = "0.24.0"
+pythonize = "0.26.0"
 serde = "1.0"
 serde_json = "1.0.143"
 
 [dependencies.pyo3]
-version = "0.24.2"
+version = "0.26.0"
 features = ["chrono", "extension-module"]

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -407,10 +407,10 @@ index = tantivy.Index(schema)
 
 # Add some documents
 writer = index.writer()
-writer.add_document(tantivy.Document(id=1, rating=3.5))
-writer.add_document(tantivy.Document(id=2, rating=4.5))
-writer.add_document(tantivy.Document(id=3, rating=3.5))
-writer.commit()
+with writer:
+    writer.add_document(tantivy.Document(id=1, rating=3.5))
+    writer.add_document(tantivy.Document(id=2, rating=4.5))
+    writer.add_document(tantivy.Document(id=3, rating=3.5))
 
 # Reload the index to make the changes available for search
 index.reload()

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -386,7 +386,7 @@ import tantivy
 # Create a schema with a numeric field
 schema_builder = tantivy.SchemaBuilder()
 schema_builder.add_integer_field("id", stored=True)
-schema_builder.add_float_field("rating", stored=True)
+schema_builder.add_float_field("rating", stored=True, fast=True)
 schema = schema_builder.build()
 
 # Create an index in RAM

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -70,6 +70,19 @@ writer.wait_merging_threads()
 Note that `wait_merging_threads()` must come at the end, because
 the `writer` object will not be usable after this call.
 
+Alternatively `writer` can be used as a context manager. The same block of code can then be written as
+
+```python
+with index.writer() as writer:
+    writer.add_document(tantivy.Document(
+        doc_id=1,
+        title=["The Old Man and the Sea"],
+        body=["""He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish."""],
+))
+```
+
+Both `commit()` and `wait_merging_threads()` is called when the with-block is exited.
+
 ## Building and Executing Queries with the Query Parser
 
 With the Query Parser, you can easily build simple queries for your index.

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,6 +3,6 @@ import nox
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session):
-    session.install("-r", "requirements-dev.txt")
+    session.install("-rrequirements-dev.txt")
     session.install("-e", ".", "--no-build-isolation")
     session.run("pytest", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,6 +3,6 @@ import nox
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session):
-    session.install("-rrequirements-dev.txt")
+    session.install("-r", "requirements-dev.txt")
     session.install("-e", ".", "--no-build-isolation")
     session.run("pytest", *session.posargs)

--- a/src/facet.rs
+++ b/src/facet.rs
@@ -88,7 +88,7 @@ impl Facet {
         other: &Self,
         op: CompareOp,
         py: Python<'_>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         match op {
             CompareOp::Eq => (self == other).into_py_any(py),
             CompareOp::Ne => (self != other).into_py_any(py),

--- a/src/index.rs
+++ b/src/index.rs
@@ -75,11 +75,18 @@ impl IndexWriter {
     /// by the client to align commits with its own document queue.
     /// The `opstamp` represents the number of documents that have been added
     /// since the creation of the index.
-    pub fn add_document(&mut self, doc: &Document) -> PyResult<u64> {
-        let named_doc = NamedFieldDocument(doc.field_values.clone());
-        let doc = TantivyDocument::convert_named_doc(&self.schema, named_doc)
-            .map_err(to_pyerr)?;
-        self.inner()?.add_document(doc).map_err(to_pyerr)
+    pub fn add_document(
+        &mut self,
+        py: Python,
+        doc: &Document,
+    ) -> PyResult<u64> {
+        py.detach(move || {
+            let named_doc = NamedFieldDocument(doc.field_values.clone());
+            let doc =
+                TantivyDocument::convert_named_doc(&self.schema, named_doc)
+                    .map_err(to_pyerr)?;
+            self.inner()?.add_document(doc).map_err(to_pyerr)
+        })
     }
 
     /// Helper for the `add_document` method, but passing a json string.
@@ -90,11 +97,13 @@ impl IndexWriter {
     /// by the client to align commits with its own document queue.
     /// The `opstamp` represents the number of documents that have been added
     /// since the creation of the index.
-    pub fn add_json(&mut self, json: &str) -> PyResult<u64> {
-        let doc = TantivyDocument::parse_json(&self.schema, json)
-            .map_err(to_pyerr)?;
-        let opstamp = self.inner()?.add_document(doc);
-        opstamp.map_err(to_pyerr)
+    pub fn add_json(&mut self, py: Python, json: &str) -> PyResult<u64> {
+        py.detach(move || {
+            let doc = TantivyDocument::parse_json(&self.schema, json)
+                .map_err(to_pyerr)?;
+            let opstamp = self.inner()?.add_document(doc);
+            opstamp.map_err(to_pyerr)
+        })
     }
 
     /// Commits all of the pending changes
@@ -106,8 +115,8 @@ impl IndexWriter {
     /// spared), it will be possible to resume indexing from this point.
     ///
     /// Returns the `opstamp` of the last document that made it in the commit.
-    fn commit(&mut self) -> PyResult<u64> {
-        self.inner_mut()?.commit().map_err(to_pyerr)
+    fn commit(&mut self, py: Python) -> PyResult<u64> {
+        py.detach(move || self.inner_mut()?.commit().map_err(to_pyerr))
     }
 
     /// Rollback to the last commit
@@ -115,21 +124,26 @@ impl IndexWriter {
     /// This cancels all of the update that happened before after the last
     /// commit. After calling rollback, the index is in the same state as it
     /// was after the last commit.
-    fn rollback(&mut self) -> PyResult<u64> {
-        self.inner_mut()?.rollback().map_err(to_pyerr)
+    fn rollback(&mut self, py: Python) -> PyResult<u64> {
+        py.detach(move || self.inner_mut()?.rollback().map_err(to_pyerr))
     }
 
     /// Detect and removes the files that are not used by the index anymore.
-    fn garbage_collect_files(&mut self) -> PyResult<()> {
-        use futures::executor::block_on;
-        block_on(self.inner()?.garbage_collect_files()).map_err(to_pyerr)?;
-        Ok(())
+    fn garbage_collect_files(&mut self, py: Python) -> PyResult<()> {
+        py.detach(move || {
+            use futures::executor::block_on;
+            block_on(self.inner()?.garbage_collect_files())
+                .map_err(to_pyerr)?;
+            Ok(())
+        })
     }
 
     /// Deletes all documents from the index.
-    fn delete_all_documents(&mut self) -> PyResult<()> {
-        self.inner()?.delete_all_documents().map_err(to_pyerr)?;
-        Ok(())
+    fn delete_all_documents(&mut self, py: Python) -> PyResult<()> {
+        py.detach(move || {
+            self.inner()?.delete_all_documents().map_err(to_pyerr)?;
+            Ok(())
+        })
     }
 
     /// The opstamp of the last successful commit.
@@ -140,8 +154,20 @@ impl IndexWriter {
     /// This is also the opstamp of the commit that is currently available
     /// for searchers.
     #[getter]
-    fn commit_opstamp(&self) -> PyResult<u64> {
-        Ok(self.inner()?.commit_opstamp())
+    fn commit_opstamp(&self, py: Python) -> PyResult<u64> {
+        py.detach(move || Ok(self.inner()?.commit_opstamp()))
+    }
+
+    #[deprecated(
+        note = "This method is deprecated and will be removed in the future. Use either delete_documents_by_term, or delete_documents_by_query."
+    )]
+    fn delete_documents(
+        &mut self,
+        py: Python,
+        field_name: &str,
+        field_value: &Bound<PyAny>,
+    ) -> PyResult<u64> {
+        self.delete_documents_by_term(py, field_name, field_value)
     }
 
     /// Delete all documents containing a given term.
@@ -167,47 +193,50 @@ impl IndexWriter {
     /// If the field_value is not supported raises Exception.
     fn delete_documents_by_term(
         &mut self,
+        py: Python,
         field_name: &str,
         field_value: &Bound<PyAny>,
     ) -> PyResult<u64> {
         let field = get_field(&self.schema, field_name)?;
         let value = extract_value(field_value)?;
-        let term = match value {
-            Value::Null => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is null type not deletable."
-                )))
-            },
-            Value::Str(text) => Term::from_field_text(field, &text),
-            Value::U64(num) => Term::from_field_u64(field, num),
-            Value::I64(num) => Term::from_field_i64(field, num),
-            Value::F64(num) => Term::from_field_f64(field, num),
-            Value::Date(d) => Term::from_field_date(field, d),
-            Value::Facet(facet) => Term::from_facet(field, &facet),
-            Value::Bytes(_) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is bytes type not deletable."
-                )))
-            }
-            Value::PreTokStr(_pretok) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is pretokenized. This is not authorized for delete."
-                )))
-            }
-            Value::Array(_) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is array type not deletable."
-                )))
-            }
-            Value::Object(_) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is json object type not deletable."
-                )))
-            },
-            Value::Bool(b) => Term::from_field_bool(field, b),
-            Value::IpAddr(i) => Term::from_field_ip_addr(field, i)
-        };
-        Ok(self.inner()?.delete_term(term))
+        py.detach(move || {
+            let term = match value {
+                Value::Null => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is null type not deletable."
+                    )))
+                },
+                Value::Str(text) => Term::from_field_text(field, &text),
+                Value::U64(num) => Term::from_field_u64(field, num),
+                Value::I64(num) => Term::from_field_i64(field, num),
+                Value::F64(num) => Term::from_field_f64(field, num),
+                Value::Date(d) => Term::from_field_date(field, d),
+                Value::Facet(facet) => Term::from_facet(field, &facet),
+                Value::Bytes(_) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is bytes type not deletable."
+                    )))
+                }
+                Value::PreTokStr(_pretok) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is pretokenized. This is not authorized for delete."
+                    )))
+                }
+                Value::Array(_) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is array type not deletable."
+                    )))
+                }
+                Value::Object(_) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is json object type not deletable."
+                    )))
+                },
+                Value::Bool(b) => Term::from_field_bool(field, b),
+                Value::IpAddr(i) => Term::from_field_ip_addr(field, i)
+            };
+            Ok(self.inner()?.delete_term(term))
+        })
     }
 
     /// Delete all documents matching a given query.
@@ -239,10 +268,13 @@ impl IndexWriter {
     ///
     /// If the query is not valid raises ValueError exception.
     /// If the query is not supported raises Exception.
-    fn delete_documents_by_query(&mut self, query: &Query) -> PyResult<u64> {
-        self.inner()?
-            .delete_query(query.inner.box_clone())
-            .map_err(to_pyerr)
+    fn delete_documents_by_query(
+        &mut self,
+        py: Python,
+        query: &Query,
+    ) -> PyResult<u64> {
+        let q = query.inner.box_clone();
+        py.detach(move || self.inner()?.delete_query(q).map_err(to_pyerr))
     }
 
     /// If there are some merging threads, blocks until they all finish
@@ -250,8 +282,25 @@ impl IndexWriter {
     ///
     /// This will consume the `IndexWriter`. Further accesses to the
     /// object will result in an error.
-    pub fn wait_merging_threads(&mut self) -> PyResult<()> {
-        self.take_inner()?.wait_merging_threads().map_err(to_pyerr)
+    pub fn wait_merging_threads(&mut self, py: Python) -> PyResult<()> {
+        py.detach(move || {
+            self.take_inner()?.wait_merging_threads().map_err(to_pyerr)
+        })
+    }
+
+    pub fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    pub fn __exit__(
+        &mut self,
+        py: Python,
+        _exc_type: Py<PyAny>,
+        _exc_value: Py<PyAny>,
+        _traceback: Py<PyAny>,
+    ) {
+        let _ = self.commit(py);
+        let _ = self.wait_merging_threads(py);
     }
 }
 
@@ -275,39 +324,51 @@ pub(crate) struct Index {
 #[pymethods]
 impl Index {
     #[staticmethod]
-    fn open(path: &str) -> PyResult<Index> {
-        let index = tv::Index::open_in_dir(path).map_err(to_pyerr)?;
+    fn open(py: Python, path: &str) -> PyResult<Index> {
+        py.detach(move || {
+            let index = tv::Index::open_in_dir(path).map_err(to_pyerr)?;
 
-        Index::register_custom_text_analyzers(&index);
+            Index::register_custom_text_analyzers(&index);
 
-        let reader = index.reader().map_err(to_pyerr)?;
-        Ok(Index { index, reader })
+            let reader = index.reader().map_err(to_pyerr)?;
+            Ok(Index { index, reader })
+        })
     }
 
     #[new]
     #[pyo3(signature = (schema, path = None, reuse = true))]
-    fn new(schema: &Schema, path: Option<&str>, reuse: bool) -> PyResult<Self> {
-        let index = match path {
-            Some(p) => {
-                let directory = MmapDirectory::open(p).map_err(to_pyerr)?;
-                if reuse {
-                    tv::Index::open_or_create(directory, schema.inner.clone())
-                } else {
-                    tv::Index::create(
-                        directory,
-                        schema.inner.clone(),
-                        tv::IndexSettings::default(),
-                    )
+    fn new(
+        py: Python,
+        schema: &Schema,
+        path: Option<&str>,
+        reuse: bool,
+    ) -> PyResult<Self> {
+        py.detach(move || {
+            let index = match path {
+                Some(p) => {
+                    let directory = MmapDirectory::open(p).map_err(to_pyerr)?;
+                    if reuse {
+                        tv::Index::open_or_create(
+                            directory,
+                            schema.inner.clone(),
+                        )
+                    } else {
+                        tv::Index::create(
+                            directory,
+                            schema.inner.clone(),
+                            tv::IndexSettings::default(),
+                        )
+                    }
+                    .map_err(to_pyerr)?
                 }
-                .map_err(to_pyerr)?
-            }
-            None => tv::Index::create_in_ram(schema.inner.clone()),
-        };
+                None => tv::Index::create_in_ram(schema.inner.clone()),
+            };
 
-        Index::register_custom_text_analyzers(&index);
+            Index::register_custom_text_analyzers(&index);
 
-        let reader = index.reader().map_err(to_pyerr)?;
-        Ok(Index { index, reader })
+            let reader = index.reader().map_err(to_pyerr)?;
+            Ok(Index { index, reader })
+        })
     }
 
     /// Create a `IndexWriter` for the index.
@@ -331,18 +392,21 @@ impl Index {
     #[pyo3(signature = (heap_size = 128_000_000, num_threads = 0))]
     fn writer(
         &self,
+        py: Python,
         heap_size: usize,
         num_threads: usize,
     ) -> PyResult<IndexWriter> {
-        let writer = match num_threads {
-            0 => self.index.writer(heap_size),
-            _ => self.index.writer_with_num_threads(num_threads, heap_size),
-        }
-        .map_err(to_pyerr)?;
-        let schema = self.index.schema();
-        Ok(IndexWriter {
-            inner_index_writer: Some(writer),
-            schema,
+        py.detach(move || {
+            let writer = match num_threads {
+                0 => self.index.writer(heap_size),
+                _ => self.index.writer_with_num_threads(num_threads, heap_size),
+            }
+            .map_err(to_pyerr)?;
+            let schema = self.index.schema();
+            Ok(IndexWriter {
+                inner_index_writer: Some(writer),
+                schema,
+            })
         })
     }
 
@@ -356,39 +420,42 @@ impl Index {
     #[pyo3(signature = (reload_policy = RELOAD_POLICY, num_warmers = 0))]
     fn config_reader(
         &mut self,
+        py: Python,
         reload_policy: &str,
         num_warmers: usize,
     ) -> Result<(), PyErr> {
-        let reload_policy = reload_policy.to_lowercase();
-        let reload_policy = match reload_policy.as_ref() {
-            "commit" => tv::ReloadPolicy::OnCommitWithDelay,
-            "on-commit" => tv::ReloadPolicy::OnCommitWithDelay,
-            "oncommit" => tv::ReloadPolicy::OnCommitWithDelay,
-            "manual" => tv::ReloadPolicy::Manual,
-            _ => return Err(exceptions::PyValueError::new_err(
-                "Invalid reload policy, valid choices are: 'manual' and 'OnCommit'"
-            ))
-        };
-        let builder = self.index.reader_builder();
-        let builder = builder.reload_policy(reload_policy);
-        let builder = if num_warmers > 0 {
-            builder.num_warming_threads(num_warmers)
-        } else {
-            builder
-        };
+        py.detach(move || {
+            let reload_policy = reload_policy.to_lowercase();
+            let reload_policy = match reload_policy.as_ref() {
+                "commit" => tv::ReloadPolicy::OnCommitWithDelay,
+                "on-commit" => tv::ReloadPolicy::OnCommitWithDelay,
+                "oncommit" => tv::ReloadPolicy::OnCommitWithDelay,
+                "manual" => tv::ReloadPolicy::Manual,
+                _ => return Err(exceptions::PyValueError::new_err(
+                    "Invalid reload policy, valid choices are: 'manual' and 'OnCommit'"
+                ))
+            };
+            let builder = self.index.reader_builder();
+            let builder = builder.reload_policy(reload_policy);
+            let builder = if num_warmers > 0 {
+                builder.num_warming_threads(num_warmers)
+            } else {
+                builder
+            };
 
-        self.reader = builder.try_into().map_err(to_pyerr)?;
-        Ok(())
+            self.reader = builder.try_into().map_err(to_pyerr)?;
+            Ok(())
+        })
     }
 
     /// Returns a searcher
     ///
     /// This method should be called every single time a search query is performed.
     /// The same searcher must be used for a given query, as it ensures the use of a consistent segment set.
-    fn searcher(&self) -> Searcher {
-        Searcher {
+    fn searcher(&self, py: Python) -> Searcher {
+        py.detach(move || Searcher {
             inner: self.reader.searcher(),
-        }
+        })
     }
 
     /// Check if the given path contains an existing index.
@@ -399,16 +466,20 @@ impl Index {
     ///
     /// Raises OSError if the directory cannot be opened.
     #[staticmethod]
-    fn exists(path: &str) -> PyResult<bool> {
-        let directory = MmapDirectory::open(path).map_err(to_pyerr)?;
-        tv::Index::exists(&directory).map_err(to_pyerr)
+    fn exists(py: Python, path: &str) -> PyResult<bool> {
+        py.detach(move || {
+            let directory = MmapDirectory::open(path).map_err(to_pyerr)?;
+            tv::Index::exists(&directory).map_err(to_pyerr)
+        })
     }
 
     /// The schema of the current index.
     #[getter]
-    fn schema(&self) -> Schema {
-        let schema = self.index.schema();
-        Schema { inner: schema }
+    fn schema(&self, py: Python) -> Schema {
+        py.detach(move || {
+            let schema = self.index.schema();
+            Schema { inner: schema }
+        })
     }
 
     /// Update searchers so that they reflect the state of the last .commit().
@@ -416,8 +487,8 @@ impl Index {
     /// If you set up the the reload policy to be on 'commit' (which is the
     /// default) every commit should be rapidly reflected on your IndexReader
     /// and you should not need to call reload() at all.
-    fn reload(&self) -> PyResult<()> {
-        self.reader.reload().map_err(to_pyerr)
+    fn reload(&self, py: Python) -> PyResult<()> {
+        py.detach(move || self.reader.reload().map_err(to_pyerr))
     }
 
     /// Parse a query
@@ -440,20 +511,23 @@ impl Index {
     #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new()))]
     pub fn parse_query(
         &self,
+        py: Python,
         query: &str,
         default_field_names: Option<Vec<String>>,
         field_boosts: HashMap<String, tv::Score>,
         fuzzy_fields: HashMap<String, (bool, u8, bool)>,
     ) -> PyResult<Query> {
-        let parser = self.prepare_query_parser(
-            default_field_names,
-            field_boosts,
-            fuzzy_fields,
-        )?;
+        py.detach(move || {
+            let parser = self.prepare_query_parser(
+                default_field_names,
+                field_boosts,
+                fuzzy_fields,
+            )?;
 
-        let query = parser.parse_query(query).map_err(to_pyerr)?;
+            let query = parser.parse_query(&query).map_err(to_pyerr)?;
 
-        Ok(Query { inner: query })
+            Ok(Query { inner: query })
+        })
     }
 
     /// Parse a query leniently.
@@ -485,25 +559,27 @@ impl Index {
     #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new()))]
     pub fn parse_query_lenient(
         &self,
+        py: Python,
         query: &str,
         default_field_names: Option<Vec<String>>,
         field_boosts: HashMap<String, tv::Score>,
         fuzzy_fields: HashMap<String, (bool, u8, bool)>,
-        py: Python,
-    ) -> PyResult<(Query, Vec<PyObject>)> {
+    ) -> PyResult<(Query, Vec<Py<PyAny>>)> {
         let parser = self.prepare_query_parser(
             default_field_names,
             field_boosts,
             fuzzy_fields,
         )?;
 
-        let (query, errors) = parser.parse_query_lenient(query);
+        let (query, errors) =
+            py.detach(move || parser.parse_query_lenient(&query));
+
         let errors = errors
             .into_iter()
             .map(|err| err.into_py(py))
             // This is a rust idiom, but just in case you're not familiar
-            // with it, we're converting from an iterator of PyResult<PyObject>
-            // into a PyResult<Vec<PyObject>>, by specifying the `PyResult`
+            // with it, we're converting from an iterator of PyResult<Py<PyAny>>
+            // into a PyResult<Vec<Py<PyAny>>>, by specifying the `PyResult`
             // on the outside of the turbofish type signature.
             .collect::<PyResult<_>>()?;
 
@@ -515,8 +591,15 @@ impl Index {
     /// TextAnalyzer instance.)
     ///
     // Implementation notes: Skipped indirection of TokenizerManager.
-    pub fn register_tokenizer(&self, name: &str, analyzer: PyTextAnalyzer) {
-        self.index.tokenizers().register(name, analyzer.analyzer);
+    pub fn register_tokenizer(
+        &self,
+        py: Python,
+        name: &str,
+        analyzer: PyTextAnalyzer,
+    ) {
+        py.detach(move || {
+            self.index.tokenizers().register(&name, analyzer.analyzer);
+        });
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -264,20 +264,6 @@ impl IndexWriter {
     pub fn wait_merging_threads(&mut self) -> PyResult<()> {
         self.take_inner()?.wait_merging_threads().map_err(to_pyerr)
     }
-
-    pub fn __enter__(slf: Py<Self>) -> Py<Self> {
-        slf
-    }
-
-    pub fn __exit__(
-        &mut self,
-        _exc_type: PyObject,
-        _exc_value: PyObject,
-        _traceback: PyObject,
-    ) {
-        self.commit();
-        self.wait_merging_threads();
-    }
 }
 
 /// Create a new index object.

--- a/src/index.rs
+++ b/src/index.rs
@@ -144,17 +144,6 @@ impl IndexWriter {
         Ok(self.inner()?.commit_opstamp())
     }
 
-    #[deprecated(
-        note = "This method is deprecated and will be removed in the future. Use either delete_documents_by_term, or delete_documents_by_query."
-    )]
-    fn delete_documents(
-        &mut self,
-        field_name: &str,
-        field_value: &Bound<PyAny>,
-    ) -> PyResult<u64> {
-        self.delete_documents_by_term(field_name, field_value)
-    }
-
     /// Delete all documents containing a given term.
     ///
     /// This method does not parse the given term and it expects the term to be

--- a/src/index.rs
+++ b/src/index.rs
@@ -75,11 +75,18 @@ impl IndexWriter {
     /// by the client to align commits with its own document queue.
     /// The `opstamp` represents the number of documents that have been added
     /// since the creation of the index.
-    pub fn add_document(&mut self, doc: &Document) -> PyResult<u64> {
-        let named_doc = NamedFieldDocument(doc.field_values.clone());
-        let doc = TantivyDocument::convert_named_doc(&self.schema, named_doc)
-            .map_err(to_pyerr)?;
-        self.inner()?.add_document(doc).map_err(to_pyerr)
+    pub fn add_document(
+        &mut self,
+        py: Python,
+        doc: &Document,
+    ) -> PyResult<u64> {
+        py.detach(move || {
+            let named_doc = NamedFieldDocument(doc.field_values.clone());
+            let doc =
+                TantivyDocument::convert_named_doc(&self.schema, named_doc)
+                    .map_err(to_pyerr)?;
+            self.inner()?.add_document(doc).map_err(to_pyerr)
+        })
     }
 
     /// Helper for the `add_document` method, but passing a json string.
@@ -90,11 +97,13 @@ impl IndexWriter {
     /// by the client to align commits with its own document queue.
     /// The `opstamp` represents the number of documents that have been added
     /// since the creation of the index.
-    pub fn add_json(&mut self, json: &str) -> PyResult<u64> {
-        let doc = TantivyDocument::parse_json(&self.schema, json)
-            .map_err(to_pyerr)?;
-        let opstamp = self.inner()?.add_document(doc);
-        opstamp.map_err(to_pyerr)
+    pub fn add_json(&mut self, py: Python, json: &str) -> PyResult<u64> {
+        py.detach(move || {
+            let doc = TantivyDocument::parse_json(&self.schema, json)
+                .map_err(to_pyerr)?;
+            let opstamp = self.inner()?.add_document(doc);
+            opstamp.map_err(to_pyerr)
+        })
     }
 
     /// Commits all of the pending changes
@@ -106,8 +115,8 @@ impl IndexWriter {
     /// spared), it will be possible to resume indexing from this point.
     ///
     /// Returns the `opstamp` of the last document that made it in the commit.
-    fn commit(&mut self) -> PyResult<u64> {
-        self.inner_mut()?.commit().map_err(to_pyerr)
+    fn commit(&mut self, py: Python) -> PyResult<u64> {
+        py.detach(move || self.inner_mut()?.commit().map_err(to_pyerr))
     }
 
     /// Rollback to the last commit
@@ -115,21 +124,26 @@ impl IndexWriter {
     /// This cancels all of the update that happened before after the last
     /// commit. After calling rollback, the index is in the same state as it
     /// was after the last commit.
-    fn rollback(&mut self) -> PyResult<u64> {
-        self.inner_mut()?.rollback().map_err(to_pyerr)
+    fn rollback(&mut self, py: Python) -> PyResult<u64> {
+        py.detach(move || self.inner_mut()?.rollback().map_err(to_pyerr))
     }
 
     /// Detect and removes the files that are not used by the index anymore.
-    fn garbage_collect_files(&mut self) -> PyResult<()> {
-        use futures::executor::block_on;
-        block_on(self.inner()?.garbage_collect_files()).map_err(to_pyerr)?;
-        Ok(())
+    fn garbage_collect_files(&mut self, py: Python) -> PyResult<()> {
+        py.detach(move || {
+            use futures::executor::block_on;
+            block_on(self.inner()?.garbage_collect_files())
+                .map_err(to_pyerr)?;
+            Ok(())
+        })
     }
 
     /// Deletes all documents from the index.
-    fn delete_all_documents(&mut self) -> PyResult<()> {
-        self.inner()?.delete_all_documents().map_err(to_pyerr)?;
-        Ok(())
+    fn delete_all_documents(&mut self, py: Python) -> PyResult<()> {
+        py.detach(move || {
+            self.inner()?.delete_all_documents().map_err(to_pyerr)?;
+            Ok(())
+        })
     }
 
     /// The opstamp of the last successful commit.
@@ -140,8 +154,8 @@ impl IndexWriter {
     /// This is also the opstamp of the commit that is currently available
     /// for searchers.
     #[getter]
-    fn commit_opstamp(&self) -> PyResult<u64> {
-        Ok(self.inner()?.commit_opstamp())
+    fn commit_opstamp(&self, py: Python) -> PyResult<u64> {
+        py.detach(move || Ok(self.inner()?.commit_opstamp()))
     }
 
     #[deprecated(
@@ -149,10 +163,11 @@ impl IndexWriter {
     )]
     fn delete_documents(
         &mut self,
+        py: Python,
         field_name: &str,
         field_value: &Bound<PyAny>,
     ) -> PyResult<u64> {
-        self.delete_documents_by_term(field_name, field_value)
+        self.delete_documents_by_term(py, field_name, field_value)
     }
 
     /// Delete all documents containing a given term.
@@ -178,47 +193,50 @@ impl IndexWriter {
     /// If the field_value is not supported raises Exception.
     fn delete_documents_by_term(
         &mut self,
+        py: Python,
         field_name: &str,
         field_value: &Bound<PyAny>,
     ) -> PyResult<u64> {
         let field = get_field(&self.schema, field_name)?;
         let value = extract_value(field_value)?;
-        let term = match value {
-            Value::Null => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is null type not deletable."
-                )))
-            },
-            Value::Str(text) => Term::from_field_text(field, &text),
-            Value::U64(num) => Term::from_field_u64(field, num),
-            Value::I64(num) => Term::from_field_i64(field, num),
-            Value::F64(num) => Term::from_field_f64(field, num),
-            Value::Date(d) => Term::from_field_date(field, d),
-            Value::Facet(facet) => Term::from_facet(field, &facet),
-            Value::Bytes(_) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is bytes type not deletable."
-                )))
-            }
-            Value::PreTokStr(_pretok) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is pretokenized. This is not authorized for delete."
-                )))
-            }
-            Value::Array(_) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is array type not deletable."
-                )))
-            }
-            Value::Object(_) => {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Field `{field_name}` is json object type not deletable."
-                )))
-            },
-            Value::Bool(b) => Term::from_field_bool(field, b),
-            Value::IpAddr(i) => Term::from_field_ip_addr(field, i)
-        };
-        Ok(self.inner()?.delete_term(term))
+        py.detach(move || {
+            let term = match value {
+                Value::Null => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is null type not deletable."
+                    )))
+                },
+                Value::Str(text) => Term::from_field_text(field, &text),
+                Value::U64(num) => Term::from_field_u64(field, num),
+                Value::I64(num) => Term::from_field_i64(field, num),
+                Value::F64(num) => Term::from_field_f64(field, num),
+                Value::Date(d) => Term::from_field_date(field, d),
+                Value::Facet(facet) => Term::from_facet(field, &facet),
+                Value::Bytes(_) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is bytes type not deletable."
+                    )))
+                }
+                Value::PreTokStr(_pretok) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is pretokenized. This is not authorized for delete."
+                    )))
+                }
+                Value::Array(_) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is array type not deletable."
+                    )))
+                }
+                Value::Object(_) => {
+                    return Err(exceptions::PyValueError::new_err(format!(
+                        "Field `{field_name}` is json object type not deletable."
+                    )))
+                },
+                Value::Bool(b) => Term::from_field_bool(field, b),
+                Value::IpAddr(i) => Term::from_field_ip_addr(field, i)
+            };
+            Ok(self.inner()?.delete_term(term))
+        })
     }
 
     /// Delete all documents matching a given query.
@@ -250,10 +268,13 @@ impl IndexWriter {
     ///
     /// If the query is not valid raises ValueError exception.
     /// If the query is not supported raises Exception.
-    fn delete_documents_by_query(&mut self, query: &Query) -> PyResult<u64> {
-        self.inner()?
-            .delete_query(query.inner.box_clone())
-            .map_err(to_pyerr)
+    fn delete_documents_by_query(
+        &mut self,
+        py: Python,
+        query: &Query,
+    ) -> PyResult<u64> {
+        let q = query.inner.box_clone();
+        py.detach(move || self.inner()?.delete_query(q).map_err(to_pyerr))
     }
 
     /// If there are some merging threads, blocks until they all finish
@@ -261,8 +282,10 @@ impl IndexWriter {
     ///
     /// This will consume the `IndexWriter`. Further accesses to the
     /// object will result in an error.
-    pub fn wait_merging_threads(&mut self) -> PyResult<()> {
-        self.take_inner()?.wait_merging_threads().map_err(to_pyerr)
+    pub fn wait_merging_threads(&mut self, py: Python) -> PyResult<()> {
+        py.detach(move || {
+            self.take_inner()?.wait_merging_threads().map_err(to_pyerr)
+        })
     }
 
     pub fn __enter__(slf: Py<Self>) -> Py<Self> {
@@ -271,12 +294,13 @@ impl IndexWriter {
 
     pub fn __exit__(
         &mut self,
-        _exc_type: PyObject,
-        _exc_value: PyObject,
-        _traceback: PyObject,
+        py: Python,
+        _exc_type: Py<PyAny>,
+        _exc_value: Py<PyAny>,
+        _traceback: Py<PyAny>,
     ) {
-        self.commit();
-        self.wait_merging_threads();
+        let _ = self.commit(py);
+        let _ = self.wait_merging_threads(py);
     }
 }
 
@@ -300,39 +324,51 @@ pub(crate) struct Index {
 #[pymethods]
 impl Index {
     #[staticmethod]
-    fn open(path: &str) -> PyResult<Index> {
-        let index = tv::Index::open_in_dir(path).map_err(to_pyerr)?;
+    fn open(py: Python, path: &str) -> PyResult<Index> {
+        py.detach(move || {
+            let index = tv::Index::open_in_dir(path).map_err(to_pyerr)?;
 
-        Index::register_custom_text_analyzers(&index);
+            Index::register_custom_text_analyzers(&index);
 
-        let reader = index.reader().map_err(to_pyerr)?;
-        Ok(Index { index, reader })
+            let reader = index.reader().map_err(to_pyerr)?;
+            Ok(Index { index, reader })
+        })
     }
 
     #[new]
     #[pyo3(signature = (schema, path = None, reuse = true))]
-    fn new(schema: &Schema, path: Option<&str>, reuse: bool) -> PyResult<Self> {
-        let index = match path {
-            Some(p) => {
-                let directory = MmapDirectory::open(p).map_err(to_pyerr)?;
-                if reuse {
-                    tv::Index::open_or_create(directory, schema.inner.clone())
-                } else {
-                    tv::Index::create(
-                        directory,
-                        schema.inner.clone(),
-                        tv::IndexSettings::default(),
-                    )
+    fn new(
+        py: Python,
+        schema: &Schema,
+        path: Option<&str>,
+        reuse: bool,
+    ) -> PyResult<Self> {
+        py.detach(move || {
+            let index = match path {
+                Some(p) => {
+                    let directory = MmapDirectory::open(p).map_err(to_pyerr)?;
+                    if reuse {
+                        tv::Index::open_or_create(
+                            directory,
+                            schema.inner.clone(),
+                        )
+                    } else {
+                        tv::Index::create(
+                            directory,
+                            schema.inner.clone(),
+                            tv::IndexSettings::default(),
+                        )
+                    }
+                    .map_err(to_pyerr)?
                 }
-                .map_err(to_pyerr)?
-            }
-            None => tv::Index::create_in_ram(schema.inner.clone()),
-        };
+                None => tv::Index::create_in_ram(schema.inner.clone()),
+            };
 
-        Index::register_custom_text_analyzers(&index);
+            Index::register_custom_text_analyzers(&index);
 
-        let reader = index.reader().map_err(to_pyerr)?;
-        Ok(Index { index, reader })
+            let reader = index.reader().map_err(to_pyerr)?;
+            Ok(Index { index, reader })
+        })
     }
 
     /// Create a `IndexWriter` for the index.
@@ -356,18 +392,21 @@ impl Index {
     #[pyo3(signature = (heap_size = 128_000_000, num_threads = 0))]
     fn writer(
         &self,
+        py: Python,
         heap_size: usize,
         num_threads: usize,
     ) -> PyResult<IndexWriter> {
-        let writer = match num_threads {
-            0 => self.index.writer(heap_size),
-            _ => self.index.writer_with_num_threads(num_threads, heap_size),
-        }
-        .map_err(to_pyerr)?;
-        let schema = self.index.schema();
-        Ok(IndexWriter {
-            inner_index_writer: Some(writer),
-            schema,
+        py.detach(move || {
+            let writer = match num_threads {
+                0 => self.index.writer(heap_size),
+                _ => self.index.writer_with_num_threads(num_threads, heap_size),
+            }
+            .map_err(to_pyerr)?;
+            let schema = self.index.schema();
+            Ok(IndexWriter {
+                inner_index_writer: Some(writer),
+                schema,
+            })
         })
     }
 
@@ -381,39 +420,42 @@ impl Index {
     #[pyo3(signature = (reload_policy = RELOAD_POLICY, num_warmers = 0))]
     fn config_reader(
         &mut self,
+        py: Python,
         reload_policy: &str,
         num_warmers: usize,
     ) -> Result<(), PyErr> {
-        let reload_policy = reload_policy.to_lowercase();
-        let reload_policy = match reload_policy.as_ref() {
-            "commit" => tv::ReloadPolicy::OnCommitWithDelay,
-            "on-commit" => tv::ReloadPolicy::OnCommitWithDelay,
-            "oncommit" => tv::ReloadPolicy::OnCommitWithDelay,
-            "manual" => tv::ReloadPolicy::Manual,
-            _ => return Err(exceptions::PyValueError::new_err(
-                "Invalid reload policy, valid choices are: 'manual' and 'OnCommit'"
-            ))
-        };
-        let builder = self.index.reader_builder();
-        let builder = builder.reload_policy(reload_policy);
-        let builder = if num_warmers > 0 {
-            builder.num_warming_threads(num_warmers)
-        } else {
-            builder
-        };
+        py.detach(move || {
+            let reload_policy = reload_policy.to_lowercase();
+            let reload_policy = match reload_policy.as_ref() {
+                "commit" => tv::ReloadPolicy::OnCommitWithDelay,
+                "on-commit" => tv::ReloadPolicy::OnCommitWithDelay,
+                "oncommit" => tv::ReloadPolicy::OnCommitWithDelay,
+                "manual" => tv::ReloadPolicy::Manual,
+                _ => return Err(exceptions::PyValueError::new_err(
+                    "Invalid reload policy, valid choices are: 'manual' and 'OnCommit'"
+                ))
+            };
+            let builder = self.index.reader_builder();
+            let builder = builder.reload_policy(reload_policy);
+            let builder = if num_warmers > 0 {
+                builder.num_warming_threads(num_warmers)
+            } else {
+                builder
+            };
 
-        self.reader = builder.try_into().map_err(to_pyerr)?;
-        Ok(())
+            self.reader = builder.try_into().map_err(to_pyerr)?;
+            Ok(())
+        })
     }
 
     /// Returns a searcher
     ///
     /// This method should be called every single time a search query is performed.
     /// The same searcher must be used for a given query, as it ensures the use of a consistent segment set.
-    fn searcher(&self) -> Searcher {
-        Searcher {
+    fn searcher(&self, py: Python) -> Searcher {
+        py.detach(move || Searcher {
             inner: self.reader.searcher(),
-        }
+        })
     }
 
     /// Check if the given path contains an existing index.
@@ -424,16 +466,20 @@ impl Index {
     ///
     /// Raises OSError if the directory cannot be opened.
     #[staticmethod]
-    fn exists(path: &str) -> PyResult<bool> {
-        let directory = MmapDirectory::open(path).map_err(to_pyerr)?;
-        tv::Index::exists(&directory).map_err(to_pyerr)
+    fn exists(py: Python, path: &str) -> PyResult<bool> {
+        py.detach(move || {
+            let directory = MmapDirectory::open(path).map_err(to_pyerr)?;
+            tv::Index::exists(&directory).map_err(to_pyerr)
+        })
     }
 
     /// The schema of the current index.
     #[getter]
-    fn schema(&self) -> Schema {
-        let schema = self.index.schema();
-        Schema { inner: schema }
+    fn schema(&self, py: Python) -> Schema {
+        py.detach(move || {
+            let schema = self.index.schema();
+            Schema { inner: schema }
+        })
     }
 
     /// Update searchers so that they reflect the state of the last .commit().
@@ -441,8 +487,8 @@ impl Index {
     /// If you set up the the reload policy to be on 'commit' (which is the
     /// default) every commit should be rapidly reflected on your IndexReader
     /// and you should not need to call reload() at all.
-    fn reload(&self) -> PyResult<()> {
-        self.reader.reload().map_err(to_pyerr)
+    fn reload(&self, py: Python) -> PyResult<()> {
+        py.detach(move || self.reader.reload().map_err(to_pyerr))
     }
 
     /// Parse a query
@@ -465,20 +511,23 @@ impl Index {
     #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new()))]
     pub fn parse_query(
         &self,
+        py: Python,
         query: &str,
         default_field_names: Option<Vec<String>>,
         field_boosts: HashMap<String, tv::Score>,
         fuzzy_fields: HashMap<String, (bool, u8, bool)>,
     ) -> PyResult<Query> {
-        let parser = self.prepare_query_parser(
-            default_field_names,
-            field_boosts,
-            fuzzy_fields,
-        )?;
+        py.detach(move || {
+            let parser = self.prepare_query_parser(
+                default_field_names,
+                field_boosts,
+                fuzzy_fields,
+            )?;
 
-        let query = parser.parse_query(query).map_err(to_pyerr)?;
+            let query = parser.parse_query(&query).map_err(to_pyerr)?;
 
-        Ok(Query { inner: query })
+            Ok(Query { inner: query })
+        })
     }
 
     /// Parse a query leniently.
@@ -510,25 +559,27 @@ impl Index {
     #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new()))]
     pub fn parse_query_lenient(
         &self,
+        py: Python,
         query: &str,
         default_field_names: Option<Vec<String>>,
         field_boosts: HashMap<String, tv::Score>,
         fuzzy_fields: HashMap<String, (bool, u8, bool)>,
-        py: Python,
-    ) -> PyResult<(Query, Vec<PyObject>)> {
+    ) -> PyResult<(Query, Vec<Py<PyAny>>)> {
         let parser = self.prepare_query_parser(
             default_field_names,
             field_boosts,
             fuzzy_fields,
         )?;
 
-        let (query, errors) = parser.parse_query_lenient(query);
+        let (query, errors) =
+            py.detach(move || parser.parse_query_lenient(&query));
+
         let errors = errors
             .into_iter()
             .map(|err| err.into_py(py))
             // This is a rust idiom, but just in case you're not familiar
-            // with it, we're converting from an iterator of PyResult<PyObject>
-            // into a PyResult<Vec<PyObject>>, by specifying the `PyResult`
+            // with it, we're converting from an iterator of PyResult<Py<PyAny>>
+            // into a PyResult<Vec<Py<PyAny>>>, by specifying the `PyResult`
             // on the outside of the turbofish type signature.
             .collect::<PyResult<_>>()?;
 
@@ -540,8 +591,15 @@ impl Index {
     /// TextAnalyzer instance.)
     ///
     // Implementation notes: Skipped indirection of TokenizerManager.
-    pub fn register_tokenizer(&self, name: &str, analyzer: PyTextAnalyzer) {
-        self.index.tokenizers().register(name, analyzer.analyzer);
+    pub fn register_tokenizer(
+        &self,
+        py: Python,
+        name: &str,
+        analyzer: PyTextAnalyzer,
+    ) {
+        py.detach(move || {
+            self.index.tokenizers().register(&name, analyzer.analyzer);
+        });
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -264,6 +264,16 @@ impl IndexWriter {
     pub fn wait_merging_threads(&mut self) -> PyResult<()> {
         self.take_inner()?.wait_merging_threads().map_err(to_pyerr)
     }
+
+    pub fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    pub fn __exit__(&mut self, _exc_type: PyObject, _exc_value: PyObject, _traceback: PyObject) {
+        self.commit();
+        self.wait_merging_threads();
+    }
+
 }
 
 /// Create a new index object.

--- a/src/index.rs
+++ b/src/index.rs
@@ -269,11 +269,15 @@ impl IndexWriter {
         slf
     }
 
-    pub fn __exit__(&mut self, _exc_type: PyObject, _exc_value: PyObject, _traceback: PyObject) {
+    pub fn __exit__(
+        &mut self,
+        _exc_type: PyObject,
+        _exc_value: PyObject,
+        _traceback: PyObject,
+    ) {
         self.commit();
         self.wait_merging_threads();
     }
-
 }
 
 /// Create a new index object.

--- a/src/parser_error.rs
+++ b/src/parser_error.rs
@@ -18,11 +18,11 @@ pub(crate) trait QueryParserError {
 /// A crate local version of the [`IntoPy`] trait to implement for
 /// [`QueryParserError`](tv::query::QueryParserError).
 pub(crate) trait QueryParserErrorIntoPy {
-    fn into_py(self, py: Python) -> PyResult<PyObject>;
+    fn into_py(self, py: Python) -> PyResult<Py<PyAny>>;
 }
 
 impl QueryParserErrorIntoPy for tv::query::QueryParserError {
-    fn into_py(self, py: Python) -> PyResult<PyObject> {
+    fn into_py(self, py: Python) -> PyResult<Py<PyAny>> {
         match self {
             tv::query::QueryParserError::SyntaxError(message) => {
                 SyntaxError { message }.into_py_any(py)

--- a/src/query.rs
+++ b/src/query.rs
@@ -12,15 +12,7 @@ use tantivy as tv;
 
 /// Custom Tuple struct to represent a pair of Occur and Query
 /// for the BooleanQuery
-struct OccurQueryPair(Occur, Query);
-
-impl<'source> FromPyObject<'source> for OccurQueryPair {
-    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
-        let (occur, query): (Occur, Query) = ob.extract()?;
-
-        Ok(OccurQueryPair(occur, query))
-    }
-}
+type OccurQueryPair = (Occur, Query);
 
 /// Tantivy's Occur
 #[pyclass(frozen, module = "tantivy.tantivy")]
@@ -205,7 +197,7 @@ impl Query {
     #[staticmethod]
     #[pyo3(signature = (subqueries))]
     pub(crate) fn boolean_query(
-        subqueries: Vec<(Occur, Query)>,
+        subqueries: Vec<OccurQueryPair>,
     ) -> PyResult<Query> {
         let dyn_subqueries = subqueries
             .into_iter()

--- a/src/query.rs
+++ b/src/query.rs
@@ -127,7 +127,7 @@ impl Query {
     /// * `schema` - Schema of the target index.
     /// * `field_name` - Field name to be searched.
     /// * `text` - String representation of the query term.
-    /// * `distance` - (Optional) Edit distance you are going to alow. When not specified, the default is 1.
+    /// * `distance` - (Optional) Edit distance you are going to allow. When not specified, the default is 1.
     /// * `transposition_cost_one` - (Optional) If true, a transposition (swapping) cost will be 1; otherwise it will be 2. When not specified, the default is true.
     /// * `prefix` - (Optional) If true, prefix levenshtein distance is applied. When not specified, the default is false.
     #[staticmethod]

--- a/src/query.rs
+++ b/src/query.rs
@@ -12,7 +12,15 @@ use tantivy as tv;
 
 /// Custom Tuple struct to represent a pair of Occur and Query
 /// for the BooleanQuery
-type OccurQueryPair = (Occur, Query);
+struct OccurQueryPair(Occur, Query);
+
+impl<'source> FromPyObject<'source> for OccurQueryPair {
+    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
+        let (occur, query): (Occur, Query) = ob.extract()?;
+
+        Ok(OccurQueryPair(occur, query))
+    }
+}
 
 /// Tantivy's Occur
 #[pyclass(frozen, module = "tantivy.tantivy")]
@@ -119,7 +127,7 @@ impl Query {
     /// * `schema` - Schema of the target index.
     /// * `field_name` - Field name to be searched.
     /// * `text` - String representation of the query term.
-    /// * `distance` - (Optional) Edit distance you are going to alow. When not specified, the default is 1.
+    /// * `distance` - (Optional) Edit distance you are going to allow. When not specified, the default is 1.
     /// * `transposition_cost_one` - (Optional) If true, a transposition (swapping) cost will be 1; otherwise it will be 2. When not specified, the default is true.
     /// * `prefix` - (Optional) If true, prefix levenshtein distance is applied. When not specified, the default is false.
     #[staticmethod]
@@ -197,7 +205,7 @@ impl Query {
     #[staticmethod]
     #[pyo3(signature = (subqueries))]
     pub(crate) fn boolean_query(
-        subqueries: Vec<OccurQueryPair>,
+        subqueries: Vec<(Occur, Query)>,
     ) -> PyResult<Query> {
         let dyn_subqueries = subqueries
             .into_iter()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -54,7 +54,7 @@ impl Schema {
         other: &Self,
         op: CompareOp,
         py: Python<'_>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         match op {
             CompareOp::Eq => (self == other).into_py_any(py),
             CompareOp::Ne => (self != other).into_py_any(py),

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -282,19 +282,21 @@ impl Searcher {
                 }
             }
         });
-        let agg_query_str = serde_json::to_string(&agg_query).map_err(to_pyerr)?;
-        let agg_query_dict: Py<PyDict> = py_json.call_method1("loads", (agg_query_str,))?.extract()?;
+        let agg_query_str =
+            serde_json::to_string(&agg_query).map_err(to_pyerr)?;
+        let agg_query_dict: Py<PyDict> =
+            py_json.call_method1("loads", (agg_query_str,))?.extract()?;
 
         let agg_res = self.aggregate(py, query, agg_query_dict)?;
         let agg_res: &Bound<PyDict> = agg_res.bind(py);
 
-        let res = agg_res
-            .get_item("cardinality")?
-            .ok_or_else(|| PyValueError::new_err("Unexpected aggregation result"))?;
+        let res = agg_res.get_item("cardinality")?.ok_or_else(|| {
+            PyValueError::new_err("Unexpected aggregation result")
+        })?;
         let res_dict: &Bound<PyDict> = res.downcast()?;
-        let value = res_dict
-            .get_item("value")?
-            .ok_or_else(|| PyValueError::new_err("Unexpected aggregation result"))?;
+        let value = res_dict.get_item("value")?.ok_or_else(|| {
+            PyValueError::new_err("Unexpected aggregation result")
+        })?;
         let res = value.extract::<f64>()?;
 
         Ok(res)

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -1,8 +1,6 @@
 import datetime
 from enum import Enum
-from types import TracebackType
 from typing import Any, Optional, Sequence, TypeVar, Union
-from typing_extensions import Self
 
 
 class Schema:
@@ -410,17 +408,6 @@ class IndexWriter:
     def wait_merging_threads(self) -> None:
         pass
 
-    def __enter__(self: Self) -> Self:
-        pass
-
-    def __exit__(
-        self: Self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        pass
-
 
 class Index:
     def __new__(
@@ -497,7 +484,6 @@ class Snippet:
     def fragment(self) -> str:
         pass
 
-
 class SnippetGenerator:
     @staticmethod
     def create(
@@ -541,6 +527,7 @@ class Tokenizer:
 
 
 class Filter:
+
     @staticmethod
     def alphanum_only() -> Filter:
         pass
@@ -575,11 +562,13 @@ class Filter:
 
 
 class TextAnalyzer:
+
     def analyze(self, text: str) -> list[str]:
         pass
 
 
 class TextAnalyzerBuilder:
+
     def __init__(self, tokenizer: Tokenizer):
         pass
 

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -1,6 +1,8 @@
 import datetime
 from enum import Enum
+from types import TracebackType
 from typing import Any, Optional, Sequence, TypeVar, Union
+from typing_extensions import Self
 
 
 class Schema:
@@ -372,6 +374,9 @@ class Searcher:
     def doc_freq(self, field_name: str, field_value: Any) -> int:
         pass
 
+    def cardinality(self, query: Query, field_name: str) -> float:
+        pass
+
 
 class IndexWriter:
     def add_document(self, doc: Document) -> int:
@@ -406,6 +411,17 @@ class IndexWriter:
         pass
 
     def wait_merging_threads(self) -> None:
+        pass
+
+    def __enter__(self: Self) -> Self:
+        pass
+
+    def __exit__(
+        self: Self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         pass
 
 
@@ -484,6 +500,7 @@ class Snippet:
     def fragment(self) -> str:
         pass
 
+
 class SnippetGenerator:
     @staticmethod
     def create(
@@ -527,7 +544,6 @@ class Tokenizer:
 
 
 class Filter:
-
     @staticmethod
     def alphanum_only() -> Filter:
         pass
@@ -562,13 +578,11 @@ class Filter:
 
 
 class TextAnalyzer:
-
     def analyze(self, text: str) -> list[str]:
         pass
 
 
 class TextAnalyzerBuilder:
-
     def __init__(self, tokenizer: Tokenizer):
         pass
 

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -1,6 +1,8 @@
 import datetime
 from enum import Enum
+from types import TracebackType
 from typing import Any, Optional, Sequence, TypeVar, Union
+from typing_extensions import Self
 
 
 class Schema:
@@ -408,6 +410,17 @@ class IndexWriter:
     def wait_merging_threads(self) -> None:
         pass
 
+    def __enter__(self: Self) -> Self:
+        pass
+
+    def __exit__(
+        self: Self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
 
 class Index:
     def __new__(
@@ -484,6 +497,7 @@ class Snippet:
     def fragment(self) -> str:
         pass
 
+
 class SnippetGenerator:
     @staticmethod
     def create(
@@ -527,7 +541,6 @@ class Tokenizer:
 
 
 class Filter:
-
     @staticmethod
     def alphanum_only() -> Filter:
         pass
@@ -559,16 +572,14 @@ class Filter:
     @staticmethod
     def split_compound(constituent_words: list[str]) -> Filter:
         pass
-    
+
 
 class TextAnalyzer:
-
     def analyze(self, text: str) -> list[str]:
         pass
 
 
 class TextAnalyzerBuilder:
-
     def __init__(self, tokenizer: Tokenizer):
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from tantivy import SchemaBuilder, Index, Document
 
 
-def build_schema():
+def schema():
     return (
         SchemaBuilder()
         .add_text_field("title", stored=True)
@@ -13,7 +13,7 @@ def build_schema():
     )
 
 
-def build_schema_numeric_fields():
+def schema_numeric_fields():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True, fast=True)
@@ -23,8 +23,7 @@ def build_schema_numeric_fields():
         .build()
     )
 
-
-def build_schema_with_date_field():
+def schema_with_date_field():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True)
@@ -33,8 +32,7 @@ def build_schema_with_date_field():
         .build()
     )
 
-
-def build_schema_with_ip_addr_field():
+def schema_with_ip_addr_field():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True)
@@ -43,11 +41,10 @@ def build_schema_with_ip_addr_field():
         .build()
     )
 
-
 def create_index(dir=None):
     # assume all tests will use the same documents for now
     # other methods may set up function-local indexes
-    index = Index(build_schema(), dir)
+    index = Index(schema(), dir)
     writer = index.writer(15_000_000, 1)
 
     # 2 ways of adding documents
@@ -100,7 +97,7 @@ def create_index(dir=None):
 
 
 def create_index_with_numeric_fields(dir=None):
-    index = Index(build_schema_numeric_fields(), dir)
+    index = Index(schema_numeric_fields(), dir)
     writer = index.writer(15_000_000, 1)
 
     doc = Document()
@@ -143,9 +140,8 @@ def create_index_with_numeric_fields(dir=None):
     index.reload()
     return index
 
-
 def create_index_with_date_field(dir=None):
-    index = Index(build_schema_with_date_field(), dir)
+    index = Index(schema_with_date_field(), dir)
     writer = index.writer(15_000_000, 1)
 
     doc = Document()
@@ -167,9 +163,8 @@ def create_index_with_date_field(dir=None):
     index.reload()
     return index
 
-
 def create_index_with_ip_addr_field(dir=None):
-    schema = build_schema_with_ip_addr_field()
+    schema = schema_with_ip_addr_field()
     index = Index(schema, dir)
     writer = index.writer(15_000_000, 1)
 
@@ -185,7 +180,7 @@ def create_index_with_ip_addr_field(dir=None):
             "rating": 4.5,
             "ip_addr": "127.0.0.1",
         },
-        schema,
+        schema
     )
     writer.add_document(doc)
     doc = Document.from_dict(
@@ -194,14 +189,13 @@ def create_index_with_ip_addr_field(dir=None):
             "rating": 4.5,
             "ip_addr": "::1",
         },
-        schema,
+        schema
     )
     writer.add_document(doc)
     writer.commit()
     writer.wait_merging_threads()
     index.reload()
     return index
-
 
 def spanish_schema():
     return (
@@ -268,22 +262,14 @@ def ram_index():
 def ram_index_numeric_fields():
     return create_index_with_numeric_fields()
 
-
 @pytest.fixture(scope="class")
 def ram_index_with_date_field():
     return create_index_with_date_field()
-
 
 @pytest.fixture(scope="class")
 def ram_index_with_ip_addr_field():
     return create_index_with_ip_addr_field()
 
-
 @pytest.fixture(scope="class")
 def spanish_index():
     return create_spanish_index()
-
-
-@pytest.fixture(scope="class")
-def schema():
-    return build_schema()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from tantivy import SchemaBuilder, Index, Document
 
 
-def schema():
+def build_schema():
     return (
         SchemaBuilder()
         .add_text_field("title", stored=True)
@@ -13,7 +13,7 @@ def schema():
     )
 
 
-def schema_numeric_fields():
+def build_schema_numeric_fields():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True, fast=True)
@@ -23,7 +23,8 @@ def schema_numeric_fields():
         .build()
     )
 
-def schema_with_date_field():
+
+def build_schema_with_date_field():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True)
@@ -32,7 +33,8 @@ def schema_with_date_field():
         .build()
     )
 
-def schema_with_ip_addr_field():
+
+def build_schema_with_ip_addr_field():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True)
@@ -41,10 +43,11 @@ def schema_with_ip_addr_field():
         .build()
     )
 
+
 def create_index(dir=None):
     # assume all tests will use the same documents for now
     # other methods may set up function-local indexes
-    index = Index(schema(), dir)
+    index = Index(build_schema(), dir)
     writer = index.writer(15_000_000, 1)
 
     # 2 ways of adding documents
@@ -97,7 +100,7 @@ def create_index(dir=None):
 
 
 def create_index_with_numeric_fields(dir=None):
-    index = Index(schema_numeric_fields(), dir)
+    index = Index(build_schema_numeric_fields(), dir)
     writer = index.writer(15_000_000, 1)
 
     doc = Document()
@@ -140,8 +143,9 @@ def create_index_with_numeric_fields(dir=None):
     index.reload()
     return index
 
+
 def create_index_with_date_field(dir=None):
-    index = Index(schema_with_date_field(), dir)
+    index = Index(build_schema_with_date_field(), dir)
     writer = index.writer(15_000_000, 1)
 
     doc = Document()
@@ -163,8 +167,9 @@ def create_index_with_date_field(dir=None):
     index.reload()
     return index
 
+
 def create_index_with_ip_addr_field(dir=None):
-    schema = schema_with_ip_addr_field()
+    schema = build_schema_with_ip_addr_field()
     index = Index(schema, dir)
     writer = index.writer(15_000_000, 1)
 
@@ -180,7 +185,7 @@ def create_index_with_ip_addr_field(dir=None):
             "rating": 4.5,
             "ip_addr": "127.0.0.1",
         },
-        schema
+        schema,
     )
     writer.add_document(doc)
     doc = Document.from_dict(
@@ -189,13 +194,14 @@ def create_index_with_ip_addr_field(dir=None):
             "rating": 4.5,
             "ip_addr": "::1",
         },
-        schema
+        schema,
     )
     writer.add_document(doc)
     writer.commit()
     writer.wait_merging_threads()
     index.reload()
     return index
+
 
 def spanish_schema():
     return (
@@ -262,14 +268,22 @@ def ram_index():
 def ram_index_numeric_fields():
     return create_index_with_numeric_fields()
 
+
 @pytest.fixture(scope="class")
 def ram_index_with_date_field():
     return create_index_with_date_field()
+
 
 @pytest.fixture(scope="class")
 def ram_index_with_ip_addr_field():
     return create_index_with_ip_addr_field()
 
+
 @pytest.fixture(scope="class")
 def spanish_index():
     return create_spanish_index()
+
+
+@pytest.fixture(scope="class")
+def schema():
+    return build_schema()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from tantivy import SchemaBuilder, Index, Document
 
 
-def schema():
+def build_schema():
     return (
         SchemaBuilder()
         .add_text_field("title", stored=True)
@@ -13,7 +13,7 @@ def schema():
     )
 
 
-def schema_numeric_fields():
+def build_schema_numeric_fields():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True, fast=True)
@@ -23,7 +23,8 @@ def schema_numeric_fields():
         .build()
     )
 
-def schema_with_date_field():
+
+def build_schema_with_date_field():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True)
@@ -32,7 +33,8 @@ def schema_with_date_field():
         .build()
     )
 
-def schema_with_ip_addr_field():
+
+def build_schema_with_ip_addr_field():
     return (
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True)
@@ -41,10 +43,11 @@ def schema_with_ip_addr_field():
         .build()
     )
 
+
 def create_index(dir=None):
     # assume all tests will use the same documents for now
     # other methods may set up function-local indexes
-    index = Index(schema(), dir)
+    index = Index(build_schema(), dir)
     writer = index.writer(15_000_000, 1)
 
     # 2 ways of adding documents
@@ -97,7 +100,7 @@ def create_index(dir=None):
 
 
 def create_index_with_numeric_fields(dir=None):
-    index = Index(schema_numeric_fields(), dir)
+    index = Index(build_schema_numeric_fields(), dir)
     writer = index.writer(15_000_000, 1)
 
     doc = Document()
@@ -140,15 +143,16 @@ def create_index_with_numeric_fields(dir=None):
     index.reload()
     return index
 
+
 def create_index_with_date_field(dir=None):
-    index = Index(schema_with_date_field(), dir)
+    index = Index(build_schema_with_date_field(), dir)
     writer = index.writer(15_000_000, 1)
 
     doc = Document()
     doc.add_integer("id", 1)
     doc.add_float("rating", 3.5)
     doc.add_date("date", datetime(2021, 1, 1))
-    
+
     writer.add_document(doc)
     doc = Document.from_dict(
         {
@@ -161,10 +165,11 @@ def create_index_with_date_field(dir=None):
     writer.commit()
     writer.wait_merging_threads()
     index.reload()
-    return index           
+    return index
+
 
 def create_index_with_ip_addr_field(dir=None):
-    schema = schema_with_ip_addr_field()
+    schema = build_schema_with_ip_addr_field()
     index = Index(schema, dir)
     writer = index.writer(15_000_000, 1)
 
@@ -173,14 +178,14 @@ def create_index_with_ip_addr_field(dir=None):
     doc.add_float("rating", 3.5)
     doc.add_ip_addr("ip_addr", "10.0.0.1")
     writer.add_document(doc)
-    
+
     doc = Document.from_dict(
         {
             "id": 2,
             "rating": 4.5,
             "ip_addr": "127.0.0.1",
         },
-        schema
+        schema,
     )
     writer.add_document(doc)
     doc = Document.from_dict(
@@ -189,13 +194,14 @@ def create_index_with_ip_addr_field(dir=None):
             "rating": 4.5,
             "ip_addr": "::1",
         },
-        schema
+        schema,
     )
     writer.add_document(doc)
     writer.commit()
     writer.wait_merging_threads()
     index.reload()
     return index
+
 
 def spanish_schema():
     return (
@@ -262,14 +268,22 @@ def ram_index():
 def ram_index_numeric_fields():
     return create_index_with_numeric_fields()
 
+
 @pytest.fixture(scope="class")
 def ram_index_with_date_field():
     return create_index_with_date_field()
+
 
 @pytest.fixture(scope="class")
 def ram_index_with_ip_addr_field():
     return create_index_with_ip_addr_field()
 
+
 @pytest.fixture(scope="class")
 def spanish_index():
     return create_spanish_index()
+
+
+@pytest.fixture(scope="class")
+def schema():
+    return build_schema()

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -146,10 +146,6 @@ class TestClass(object):
         cardinality = searcher.cardinality(query, "id")
         assert cardinality == 2.0
         
-        # Test cardinality for boolean field (has 2 unique values: True and False)
-        cardinality = searcher.cardinality(query, "is_good")
-        assert cardinality == 2.0
-        
         # Test with a query that filters to one document
         single_doc_query = Query.term_query(index.schema, "id", 1)
         cardinality = searcher.cardinality(single_doc_query, "rating")

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -582,16 +582,19 @@ class TestClass(object):
     def test_index_writer_context_block(self, schema):
         index = Index(schema)
         with index.writer() as writer:
-            writer.add_document(Document(
-                doc_id=1,
-                title=["The Old Man and the Sea"],
-                body=["""He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish."""],
-        ))
+            writer.add_document(
+                Document(
+                    doc_id=1,
+                    title=["The Old Man and the Sea"],
+                    body=[
+                        """He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish."""
+                    ],
+                )
+            )
 
         index.reload()
         result = index.searcher().search(Query.all_query())
         assert len(result.hits) == 1
-
 
 
 class TestUpdateClass(object):

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -7,7 +7,7 @@ import pickle
 import pytest
 
 import tantivy
-from conftest import schema, schema_numeric_fields
+from conftest import build_schema, build_schema_numeric_fields
 from tantivy import (
     Document,
     Index,
@@ -30,7 +30,7 @@ class TestClass(object):
 
     def test_simple_search_after_reuse(self, dir_index):
         index_dir, _ = dir_index
-        index = Index(schema(), str(index_dir))
+        index = Index(build_schema(), str(index_dir))
         query = index.parse_query("sea whale", ["title", "body"])
 
         result = index.searcher().search(query, 10)
@@ -579,6 +579,19 @@ class TestClass(object):
 
         assert len(result.hits) == 0
 
+    def test_index_writer_context_block(self, schema):
+        index = Index(schema)
+        with index.writer() as writer:
+            writer.add_document(Document(
+                doc_id=1,
+                title=["The Old Man and the Sea"],
+                body=["""He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish."""],
+        ))
+
+        index.reload()
+        result = index.searcher().search(Query.all_query())
+        assert len(result.hits) == 1
+
 
 
 class TestUpdateClass(object):
@@ -613,12 +626,12 @@ class TestFromDiskClass(object):
     def test_opens_from_dir(self, dir_index):
         index_dir, _ = dir_index
 
-        index = Index(schema(), str(index_dir), reuse=True)
+        index = Index(build_schema(), str(index_dir), reuse=True)
         assert index.searcher().num_docs == 3
 
     def test_create_readers(self):
         # not sure what is the point of this test.
-        idx = Index(schema())
+        idx = Index(build_schema())
         idx.config_reader("Manual", 4)
         assert idx.searcher().num_docs == 0
         # by default this is manual mode
@@ -823,9 +836,9 @@ def test_bytes(bytes_kwarg, bytes_payload):
 
 
 def test_schema_eq():
-    schema1 = schema()
-    schema2 = schema()
-    schema3 = schema_numeric_fields()
+    schema1 = build_schema()
+    schema2 = build_schema()
+    schema3 = build_schema_numeric_fields()
 
     assert schema1 == schema2
     assert schema1 != schema3
@@ -877,7 +890,7 @@ def test_doc_address_pickle():
 class TestSnippets(object):
     def test_document_snippet(self, dir_index):
         index_dir, _ = dir_index
-        doc_schema = schema()
+        doc_schema = build_schema()
         index = Index(doc_schema, str(index_dir))
         query = index.parse_query("sea whale", ["title", "body"])
         searcher = index.searcher()


### PR DESCRIPTION
This commit adds support for cardinality aggregation by:

- Updating the `tantivy` dependency to version 0.25.0.
- Adding a `cardinality` method to the `Searcher` class to make it easier to use this feature.